### PR TITLE
Fixing `plot_survey` in `Beamline`

### DIFF
--- a/abel/classes/beamline/beamline.py
+++ b/abel/classes/beamline/beamline.py
@@ -122,7 +122,7 @@ class Beamline(Trackable, Runnable, CostModeled):
         # extract secondary objects
         second_objs = None
         connect_to = None
-        if len(objs)==2 and isinstance(objs[1], tuple):
+        if isinstance(objs, tuple) and len(objs)==2 and isinstance(objs[1], tuple):
             second_objs = objs[1][0]
             connect_to = objs[1][1]
             objs = objs[0]


### PR DESCRIPTION
Fixed a minor issue in Beamline's plot_survey where it didn't work for lists of two elements. This was just a single line of code, and the tests all pass, so I will simply merge it.