### PR TITLE
ImpactX 25.06: Simpler APIs

### DIFF
--- a/abel/apis/impactx/impactx_api.py
+++ b/abel/apis/impactx/impactx_api.py
@@ -121,28 +121,22 @@ def run_envelope_impactx(lattice, distr, nom_energy=None, peak_current=None, spa
 
 def initialize_impactx_sim(verbose=False):
 
-    import amrex.space3d as amr
     from impactx import ImpactX
-    
-    # add before the simulation setup
-    pp_prof = amr.ParmParse("tiny_profiler")
-    pp_prof.add("enabled", int(verbose))
-    
-    # set AMReX verbosity
-    if not amr.initialized():
-        if verbose:
-            amr.initialize(["amrex.omp_threads=1", "amrex.verbose=0"])
-        else:
-            eval('amr.initialize(["amrex.omp_threads=1", "amrex.verbose=0"])')
 
     # make simulation object
     sim = ImpactX()
 
+    # serial run on one CPU core
+    sim.omp_threads = 1
+
     # set ImpactX verbosity
     sim.verbose = int(verbose)
+    sim.tiny_profiler = verbose
     
     # enable diagnostics
     sim.diagnostics = True
+    #   Note: Diagnostics in every element's slice steps is verbose.
+    #         Disable for speed if if only beam monitors and final results are needed.
     sim.slice_step_diagnostics = True
 
     # set numerical parameters and IO control
@@ -155,19 +149,9 @@ def initialize_impactx_sim(verbose=False):
 
 
 def finalize_impactx_sim(sim, verbose=False):
+    """finalize and delete the simulation"""
 
-    import amrex.space3d as amr
-    
-    # finalize and delete the simulation
     sim.finalize()
-    del sim
-    
-    # finalize AMReX
-    if amr.initialized():
-        if verbose:
-            amr.finalize()
-        else:
-            eval('amr.finalize()')
 
 
 def extract_evolution(path='', second_order=False):

--- a/abel/classes/plasma_lens/impl/plasma_lens_impactx.py
+++ b/abel/classes/plasma_lens/impl/plasma_lens_impactx.py
@@ -15,16 +15,20 @@ class PlasmaLensImpactX(PlasmaLens):
     def track(self, beam0, savedepth=0, runnable=None, verbose=False):
 
         import impactx
-        import amrex.space3d as amr
         from abel.apis.impactx.impactx_api import beam2particle_container, particle_container2beam
         
         # initialize AMReX
         verbose_debug = False
-        amr.initialize(["amrex.omp_threads=1", f"amrex.verbose={int(verbose_debug)}"])
 
         # make simulation object
         sim = impactx.ImpactX()
+
+        # serial run on one CPU core
+        sim.omp_threads = 1
+
+        # set ImpactX verbosity
         sim.verbose = int(verbose_debug)
+        sim.tiny_profiler = verbose_debug
         
         # convert to ImpactX particle container
         _, sim = beam2particle_container(beam0, sim)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -25,7 +25,7 @@ dependencies = [
    "ax-platform",
    "CLICopti >= 2.2",
    "RF-Track",
-   "impactx-noacc"
+   "impactx-noacc >= 25.06"
 ]
 requires-python = ">=3,<3.13"
 


### PR DESCRIPTION
Verbosity and OpenMP control will be simpler to set in ImpactX version 25.06. Simply ABEL accordingly and in particular, no need to externally init/finalize AMReX anymore.

Relevant PRs in ImpactX:
- https://github.com/BLAST-ImpactX/impactx/pull/998
- https://github.com/BLAST-ImpactX/impactx/pull/999

Check list:
- [x] wait for ImpactX 25.06 to be released before merging this