### PR TITLE
ImpactX: Simpler Init

### DIFF
--- a/abel/wrappers/impactx/impactx_wrapper.py
+++ b/abel/wrappers/impactx/impactx_wrapper.py
@@ -130,30 +130,11 @@ def run_envelope_impactx(lattice, distr, nom_energy=None, peak_current=None, spa
     return evol
 
 
-def initialize_amrex(verbose=False, verbose_debug=False):
-    """Initialize AMReX."""
-    
-    import amrex.space3d as amr
-
-    # add before the simulation setup
-    pp_prof = amr.ParmParse("tiny_profiler")
-    pp_prof.add("enabled", int(verbose))
-    
-    if not amr.initialized():
-        if verbose:
-            amr.initialize(['amrex.omp_threads=1', f'amrex.verbose={int(verbose_debug)}'])
-        else:
-            eval('amr.initialize(["amrex.omp_threads=1", "amrex.verbose=0"])')
-
-
 def initialize_impactx_sim(verbose=False):
     """Initialize the ImpactX simulation."""
     
     #import amrex.space3d as amr
     from impactx import ImpactX
-    
-    # set AMReX verbosity
-    initialize_amrex(verbose=verbose)
 
     # make simulation object
     sim = ImpactX()


### PR DESCRIPTION
This is adding the leftovers that were part of #73 ImpactX 25.06+ has exposed APIs to control threading and verbosity, so that we do not need to manually initialize AMReX anymore with internal variables.

I manually ran those tests locally and they still passed:
```console
pytest tests/test_impactx.py
pytest tests/test_StageReducedModels_beamline.py
```