### PR TITLE
Add Continuous Integration

### DIFF
--- a/.github/workflows/unix.yml
+++ b/.github/workflows/unix.yml
@@ -1,0 +1,40 @@
+name: Unix
+
+on: [push, pull_request]
+
+concurrency:
+  group: ${{ github.ref }}-${{ github.head_ref }}-unix
+  cancel-in-progress: true
+
+jobs:
+  unittest:
+    strategy:
+      matrix:
+        os: [ubuntu-latest]
+    runs-on: ${{ matrix.os }}
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - uses: actions/setup-python@v6
+      name: Install Python
+      with:
+        python-version-file: "pyproject.toml"
+
+    - name: Install uv
+      uses: astral-sh/setup-uv@v6
+      with:
+        activate-environment: true
+
+    - name: Install dependencies
+      run: |
+        uv pip install pytest setuptools[core] wheel
+
+    - name: Install
+      run: uv pip install -v .
+
+    - name: Create config file
+      run: python -m pytest -v tests/test_init.py::testCore_init || true
+
+    - name: Run Unit Tests
+      run: python -m pytest tests/


### PR DESCRIPTION
Now that ABEL is open source, we can make use of free GitHub action runners to run all pytest tests as part of Continuous Integration (CI) for every pull request (PR) and merged commit :tada: 
This will add a status to every PR and commit and populate the "Checks" tab in PRs, which is currently `0`.

I tested this in my fork and it looks good to start ([example test output](https://github.com/ax3l/ABEL/actions/runs/18021149129/job/51278510871)).

## Future Updates

Later on, in follow-up PRs, I would separately probably say we could develop a conda environment, with which we can install dependencies like HiPACE++ and others. But let's start somewhere for now.