### PR TITLE
Fixes the problem of the progress bar in reduced models being too long

### DIFF
--- a/abel/physics_models/particles_transverse_wake_instability.py
+++ b/abel/physics_models/particles_transverse_wake_instability.py
@@ -569,7 +569,7 @@ def transverse_wake_instability_particles(beam, drive_beam0, Ez_fit_obj, rb_fit_
 
     # Progress bar
     if show_prog_bar is True:
-        pbar = tqdm(total=100, bar_format='{desc} {percentage:3.1f}%|{bar}| [{elapsed}, {rate_fmt}{postfix}]')
+        pbar = tqdm(total=100, bar_format='{desc} {percentage:3.1f}%|{bar}| [{elapsed}, {rate_fmt}{postfix}]', ncols=100)
         pbar.set_description(f"\t>> Running reduced physics models")
         
 


### PR DESCRIPTION
Modified the length of the progress bar in `abel/physics_models/particles_transverse_wake_instability.py`.