### PR TITLE
Fixed typo in external_focusing in stage_hipace

### DIFF
--- a/abel/classes/stage/impl/stage_hipace.py
+++ b/abel/classes/stage/impl/stage_hipace.py
@@ -85,7 +85,7 @@ class StageHipace(Stage):
         
         # set external focusing
         if self.external_focusing == False:
-            self.external_focusing_gradient = 0
+            self._external_focusing_gradient = 0
         if self.external_focusing == True and self._external_focusing_gradient is None:
             num_half_oscillations = 1
             self._external_focusing_gradient = self.driver_source.energy/SI.c*(num_half_oscillations*np.pi/self.get_length())**2


### PR DESCRIPTION
In stage_hipace line 88 I changed "self.external_focusing_gradient = 0" to "self._external_focusing_gradient = 0"