### PR TITLE
Fixed bug in stage.py such that it plots the wake for both first and last step. 

### DIFF
--- a/abel/classes/stage/stage.py
+++ b/abel/classes/stage/stage.py
@@ -2089,11 +2089,11 @@ class Stage(Trackable, CostModeled):
         
         # make figures
         has_final_step = self.final is not None \
-            and hasattr(self.final, 'plasma.density.extent') \
-            and hasattr(self.final, 'plasma.wakefield.onaxis.zs') \
-            and hasattr(self.final, 'plasma.wakefield.onaxis.Ezs') \
-            and hasattr(self.final, 'plasma.density.rho') \
-            and hasattr(self.final, 'beam.density.rho')
+            and hasattr(self.final.plasma.density, 'extent') \
+            and hasattr(self.final.plasma.wakefield.onaxis, 'zs') \
+            and hasattr(self.final.plasma.wakefield.onaxis, 'Ezs') \
+            and hasattr(self.final.plasma.density, 'rho') \
+            and hasattr(self.final.beam.density, 'rho')
 
         num_plots = 1 + int(has_final_step)
         fig, ax = plt.subplots(num_plots,1)


### PR DESCRIPTION
In plot_wake in stage.py there was several lines such as hasattr(self.final, 'plasma.density.extent'). This doesn't work because the string can only contain the actual name of the attribute, not the nested structure itself.