### PR TITLE
Bugfix for keeping the HiPACE++ input file when using `Runnable.scan()`

### DIFF
--- a/src/abel/classes/stage/impl/stage_hipace.py
+++ b/src/abel/classes/stage/impl/stage_hipace.py
@@ -352,7 +352,12 @@ class StageHipace(Stage):
         path_input = tmpfolder + filename_input
         hipace_write_inputs(path_input, filename_beam, filename_driver, self.plasma_density, self.num_steps, time_step, box_range_z, box_size_xy, ion_motion=self.ion_motion, ion_species=self.ion_species, beam_ionization=self.beam_ionization, radiation_reaction=self.radiation_reaction, output_period=output_period, num_cell_xy=self.num_cell_xy, num_cell_z=num_cell_z, driver_only=self.driver_only, density_table_file=density_table_file, no_plasma=self.no_plasma, external_focusing_gradient=self._external_focusing_gradient, mesh_refinement=self.mesh_refinement, do_spin_tracking=self.do_spin_tracking)
         
-        
+        # move the HiPACE++ input file to be stored
+        if runnable is not None:
+            shutil.copy(path_input, runnable.shot_path())
+        elif self.run_path is not None:
+            shutil.copy(path_input, self.run_path)
+            
         ## RUN SIMULATION
         
         # make job script
@@ -398,10 +403,6 @@ class StageHipace(Stage):
         # extract insitu diagnostics and wakefield data
         self.__extract_evolution(tmpfolder, beam0, runnable)
         self.__extract_initial_and_final_step(tmpfolder, beam0, runnable)
-
-        # move the HiPACE++ input file to be stored
-        if self.run_path is not None:
-            shutil.move(path_input, self.run_path)
         
         # delete temp folder
         shutil.rmtree(tmpfolder)


### PR DESCRIPTION
Edited `StageHipace.track()` to copy the HiPACE++ input file into the shot folder instead of moving it into the run folder, as in PR #202. This avoids a crash when using `Runnable.scan()`.