### PR TITLE
Small bug fixes and upgrades related to Interstage (final update)

### DIFF
--- a/src/abel/classes/beam.py
+++ b/src/abel/classes/beam.py
@@ -1308,16 +1308,16 @@ class Beam():
     
     ## phase spaces
     
-    def phase_space_density(self, hfcn, vfcn, hbins=None, vbins=None, hlim=None, vlim=None):
+    def phase_space_density(self, hfcn, vfcn, hbins=None, vbins=None, hlims=None, vlims=None):
         self.remove_nans()
         if hbins is None:
             hbins = round(np.sqrt(len(self))/2)
-            if hlim is not None:
-                hbins = np.linspace(np.min(hlim), np.max(hlim), hbins)
+            if hlims is not None:
+                hbins = np.linspace(np.min(hlims), np.max(hlims), hbins)
         if vbins is None:
             vbins = round(np.sqrt(len(self))/2)
-            if vlim is not None:
-                vbins = np.linspace(np.min(vlim), np.max(vlim), vbins)
+            if vlims is not None:
+                vbins = np.linspace(np.min(vlims), np.max(vlims), vbins)
         counts, hedges, vedges = np.histogram2d(hfcn(), vfcn(), weights=self.qs(), bins=(hbins, vbins))
         hctrs = (hedges[0:-1] + hedges[1:])/2
         vctrs = (vedges[0:-1] + vedges[1:])/2
@@ -1331,10 +1331,10 @@ class Beam():
         return density, hctrs, vctrs
     
     def density_lps(self, zbins=None, Ebins=None, zlims=None, Elims=None):
-        return self.phase_space_density(self.zs, self.Es, hbins=zbins, vbins=Ebins, hlim=zlims, vlim=Elims)
+        return self.phase_space_density(self.zs, self.Es, hbins=zbins, vbins=Ebins, hlims=zlims, vlims=Elims)
     
     def density_transverse(self, hbins=None, vbins=None, xlims=None, ylims=None):
-        return self.phase_space_density(self.xs, self.ys, hbins=hbins, vbins=vbins, hlim=xlims, vlim=yElims)
+        return self.phase_space_density(self.xs, self.ys, hbins=hbins, vbins=vbins, hlims=xlims, vlims=ylims)
 
     
     # ==================================================
@@ -1709,7 +1709,7 @@ class Beam():
         cb.ax.set_ylabel('Charge density (pC/um/mrad)')
 
     def plot_transverse_profile(self, xlims=None, ylims=None):
-        dQdxdy, xs, ys = self.phase_space_density(self.xs, self.ys, xlims=xlims, ylims=ylims)
+        dQdxdy, xs, ys = self.phase_space_density(self.xs, self.ys, hlims=xlims, vlims=ylims)
 
         fig, ax = plt.subplots()
         fig.set_figwidth(8)

--- a/src/abel/classes/beam.py
+++ b/src/abel/classes/beam.py
@@ -1308,12 +1308,16 @@ class Beam():
     
     ## phase spaces
     
-    def phase_space_density(self, hfcn, vfcn, hbins=None, vbins=None):
+    def phase_space_density(self, hfcn, vfcn, hbins=None, vbins=None, hlim=None, vlim=None):
         self.remove_nans()
         if hbins is None:
             hbins = round(np.sqrt(len(self))/2)
+            if hlim is not None:
+                hbins = np.linspace(np.min(hlim), np.max(hlim), hbins)
         if vbins is None:
             vbins = round(np.sqrt(len(self))/2)
+            if vlim is not None:
+                vbins = np.linspace(np.min(vlim), np.max(vlim), vbins)
         counts, hedges, vedges = np.histogram2d(hfcn(), vfcn(), weights=self.qs(), bins=(hbins, vbins))
         hctrs = (hedges[0:-1] + hedges[1:])/2
         vctrs = (vedges[0:-1] + vedges[1:])/2
@@ -1326,11 +1330,11 @@ class Beam():
         #print(np.sum(density*np.diff(vedges)*np.diff(hedges))/self.charge())
         return density, hctrs, vctrs
     
-    def density_lps(self, hbins=None, vbins=None):
-        return self.phase_space_density(self.zs, self.Es, hbins=hbins, vbins=vbins)
+    def density_lps(self, zbins=None, Ebins=None, zlims=None, Elims=None):
+        return self.phase_space_density(self.zs, self.Es, hbins=zbins, vbins=Ebins, hlim=zlims, vlim=Elims)
     
-    def density_transverse(self, hbins=None, vbins=None):
-        return self.phase_space_density(self.xs, self.ys, hbins=hbins, vbins=vbins)
+    def density_transverse(self, hbins=None, vbins=None, xlims=None, ylims=None):
+        return self.phase_space_density(self.xs, self.ys, hbins=hbins, vbins=vbins, hlim=xlims, vlim=yElims)
 
     
     # ==================================================
@@ -1704,8 +1708,8 @@ class Beam():
         cb = fig.colorbar(p)
         cb.ax.set_ylabel('Charge density (pC/um/mrad)')
 
-    def plot_transverse_profile(self):
-        dQdxdy, xs, ys = self.phase_space_density(self.xs, self.ys)
+    def plot_transverse_profile(self, xlims=None, ylims=None):
+        dQdxdy, xs, ys = self.phase_space_density(self.xs, self.ys, xlims=xlims, ylims=ylims)
 
         fig, ax = plt.subplots()
         fig.set_figwidth(8)

--- a/src/abel/classes/interstage/__init__.py
+++ b/src/abel/classes/interstage/__init__.py
@@ -353,6 +353,7 @@ class Interstage(Trackable, CostModeled):
         from matplotlib import pyplot as plt
         from matplotlib import patches
         from copy import deepcopy
+        import string
         from abel.utilities.beam_physics import evolve_beta_function, evolve_dispersion, evolve_second_order_dispersion, evolve_R56, evolve_chromatic_amplitude
         
         # calculate evolution
@@ -368,7 +369,7 @@ class Interstage(Trackable, CostModeled):
             ss_beta = evol_beta_x[0]
             beta_xs = evol_beta_x[1]
             beta_ys = evol_beta_y[1]
-
+        
         if show_dispersion:
             _, _, evol_second_order_dispersion = evolve_second_order_dispersion(ls, inv_rhos, ks, ms, taus, fast=False);
             ss_disp = evol_second_order_dispersion[0]
@@ -453,6 +454,7 @@ class Interstage(Trackable, CostModeled):
                 axs[n].legend(loc='best', reverse=True, fontsize='small')
             axs[n].set_ylabel(r'$\sqrt{\mathrm{Beta\hspace{0.3}function}}$ ($\sqrt{\mathrm{m}})$')
             axs[n].set_xlim(long_limits)
+            axs[n].text(0.01, 0.90, f'({string.ascii_lowercase[n-1]})', transform=axs[n].transAxes, size=13)
         
         # plot dispersion
         if show_dispersion:
@@ -464,7 +466,8 @@ class Interstage(Trackable, CostModeled):
             axs[n].plot(ss_disp, dispersion / 1e-3, '-', color=colx1, label=r'1$^{\mathrm{st}}$ order')
             axs[n].set_ylabel('Horizontal dispersion (mm)')
             axs[n].set_xlim(long_limits)
-            axs[n].legend(loc='best', reverse=True, fontsize='small')
+            axs[n].legend(loc='lower left', reverse=True, fontsize='small')
+            axs[n].text(0.01, 0.90, f'({string.ascii_lowercase[n-1]})', transform=axs[n].transAxes, size=13)
         
         # plot R56
         if show_R56:
@@ -473,6 +476,7 @@ class Interstage(Trackable, CostModeled):
             axs[n].plot(ss_R56, R56/1e-3, color=colz)
             axs[n].set_ylabel(r'Longitudinal dispersion, $R_{56}$ (mm)')
             axs[n].set_xlim(long_limits)
+            axs[n].text(0.01, 0.90, f'({string.ascii_lowercase[n-1]})', transform=axs[n].transAxes, size=13)
 
         # plot chromaticity
         if show_chromaticity:
@@ -481,7 +485,7 @@ class Interstage(Trackable, CostModeled):
                 if add_no_chrom_correction:
                     axs[n].plot(ss_W0, Wxs0, ':', color=coloff, label='Linear plasma lenses')
                     axs[n].plot(ss_W, Wxs, color=colx1, label='Nonlinear plasma lenses')
-                    axs[n].legend(loc='best', reverse=True, fontsize='small')
+                    axs[n].legend(loc='upper left', reverse=True, fontsize='small', bbox_to_anchor=[0.01,0.89])
                 else:
                     axs[n].plot(ss_W, Wxs, color=colx1)
 
@@ -496,6 +500,7 @@ class Interstage(Trackable, CostModeled):
                 axs[n].set_ylim(np.array([-0.01, 1.05])*max(max(Wys), max(Wxs)))
             axs[n].set_ylabel(r'Chromatic amplitude, $W$')
             axs[n].set_xlim(long_limits)
+            axs[n].text(0.01, 0.90, f'({string.ascii_lowercase[n-1]})', transform=axs[n].transAxes, size=13)
             
 
         # add horizontal axis label
@@ -506,7 +511,7 @@ class Interstage(Trackable, CostModeled):
             fig.savefig(str(savefig), format="pdf", bbox_inches="tight")
 
     
-    def plot_layout(self, delta=0.25, axes_equal=False, use_second_order_dispersion=False, savefig=None, figsize=[12,2]):
+    def plot_layout(self, delta=0.25, axes_equal=False, use_second_order_dispersion=False, savefig=None, figsize=[12,2], add_drivers_eV=None):
         "Plot the layout with beam orbit and dispersion."
         
         from matplotlib import pyplot as plt
@@ -598,7 +603,7 @@ class Interstage(Trackable, CostModeled):
         lw_element=0.75
         if not axes_equal:
             width_dipole = max(abs(offset_disp))*2
-        width_lens = width_dipole*0.8
+        width_lens = width_dipole*0.75
         width_sextupole = width_dipole*0.75
         ssl = np.append([0.0], np.cumsum(ls))
         ssl = ssl[:-1]
@@ -640,6 +645,27 @@ class Interstage(Trackable, CostModeled):
         # invert axis to have positive values on the "right"
         ax.yaxis.set_inverted(True)
 
+        if add_drivers_eV is not None:
+            col_driver = 'tab:red'
+            
+            _, evol_orbit_driver_in = evolve_orbit(np.append(ls[:2], ssl[-1]/6), np.append(inv_rhos[:2], 0)*self.nom_energy/add_drivers_eV, theta0=-theta/2)
+            xs_driver_in = evol_orbit_driver_in[0,:]
+            ys_driver_in = evol_orbit_driver_in[1,:]
+            _, evol_orbit_driver_depl = evolve_orbit(np.append(ls[:2], ssl[-1]/24), np.append(inv_rhos[:2], 0)*self.nom_energy/add_drivers_eV*2, theta0=-theta/2)
+            xs_driver_depl = evol_orbit_driver_depl[0,:]
+            ys_driver_depl = evol_orbit_driver_depl[1,:]
+
+            ax.fill(np.concatenate([xs_driver_in, np.flip(xs_driver_depl)]), np.concatenate([ys_driver_in, np.flip(ys_driver_depl)]), col_driver, alpha=0.1, edgecolor='none', lw=lw_element, zorder=0)
+            
+            ax.plot(xs_driver_in, ys_driver_in, ':', lw=lw_dotted, c=col_driver)
+            ax.arrow(xs_driver_in[-1], ys_driver_in[-1], (xs_driver_in[-1]-xs_driver_in[-2])/100, (ys_driver_in[-1]-ys_driver_in[-2])/100, color=col_driver, width=0, head_length=width_dipole/5, head_width=width_dipole/5, zorder=100)
+
+            _, evol_orbit_driver_out = evolve_orbit(np.append(ls[:2], ssl[-1]/6), np.append(-inv_rhos[:2], 0)*self.nom_energy/add_drivers_eV, theta0=np.pi+theta/2)
+            xs_driver_out = xs[-1]+evol_orbit_driver_out[0,:]
+            ys_driver_out = ys[-1]+evol_orbit_driver_out[1,:]
+            ax.plot(xs_driver_out, ys_driver_out, ':', lw=lw_dotted, c=col_driver)
+            ax.arrow(xs_driver_out[0], ys_driver_out[0], -(xs_driver_out[2]-xs_driver_out[0])/1, -(ys_driver_out[2]-ys_driver_out[0])/1, color=col_driver, width=0, head_length=width_dipole/5, head_width=width_dipole/5, zorder=101)
+            
         # save figure to file
         if savefig is not None:
             fig.savefig(str(savefig), format="pdf", bbox_inches="tight")

--- a/src/abel/classes/interstage/plasma_lens/impactx.py
+++ b/src/abel/classes/interstage/plasma_lens/impactx.py
@@ -163,7 +163,7 @@ class InterstagePlasmaLensImpactX(InterstagePlasmaLens):
             pl2 = [aperture]
             pl2.extend(plasma_lens2)
             pl2.append(aperture)
-            plasma_lens1 = pl2
+            plasma_lens2 = pl2
 
         # define first chicane dipole
         B_chic1 = self.field_chicane_dipole1

--- a/src/abel/classes/interstage/plasma_lens/impactx.py
+++ b/src/abel/classes/interstage/plasma_lens/impactx.py
@@ -48,7 +48,7 @@ class InterstagePlasmaLensImpactX(InterstagePlasmaLens):
     # TODO: keep_data is not used.
     
     def __init__(self, nom_energy=None, beta0=None, length_dipole=None, field_dipole=None, R56=0, cancel_chromaticity=True, cancel_sec_order_dispersion=True,
-                       enable_csr=True, enable_isr=True, enable_space_charge=False, num_slices=50, use_monitors=False, enable_isr_on_ref_part=True, keep_data=False):
+                       enable_csr=True, enable_isr=True, enable_space_charge=False, num_slices=50, use_monitors=False, isr_on_ref_part=True, keep_data=False):
         
         super().__init__(nom_energy=nom_energy, beta0=beta0, length_dipole=length_dipole, field_dipole=field_dipole, R56=R56, 
                          cancel_chromaticity=cancel_chromaticity, cancel_sec_order_dispersion=cancel_sec_order_dispersion, 
@@ -57,7 +57,7 @@ class InterstagePlasmaLensImpactX(InterstagePlasmaLens):
         # simulation options
         self.num_slices = num_slices
         self.use_monitors = use_monitors
-        self.isr_on_ref_part = enable_isr_on_ref_part
+        self.isr_on_ref_part = isr_on_ref_part
 
 
     # ==================================================
@@ -132,12 +132,6 @@ class InterstagePlasmaLensImpactX(InterstagePlasmaLens):
         B_dip = self.field_dipole
         phi_dip = self.length_dipole*B_dip*SI.e/energy2momentum(self.nom_energy)
         dipole = elements.ExactSbend(ds=self.length_dipole, phi=np.rad2deg(phi_dip), B=B_dip, nslice=self.num_slices)
-
-        # add lens offset for ISR mitigation
-        if self.enable_isr and self.cancel_isr_kicks:
-            dx_isr = self.lens_offset_isr_kick_mitigation()
-        else:
-            dx_isr = 0
             
         # define plasma lens
         ds_pl = self.length_plasma_lens/(self.num_slices+1)
@@ -146,7 +140,7 @@ class InterstagePlasmaLensImpactX(InterstagePlasmaLens):
         plasma_lens2 = [drift_slice_pl]
         kl_lens = self.strength_plasma_lens
         tau_lens = self.nonlinearity_plasma_lens
-        dxs = dx_isr*np.array([1, -1]) + np.array([self.lens1_offset_x, self.lens2_offset_x]) + np.random.normal(scale=self.jitter.lens_offset_x, size=2)
+        dxs = np.array([self.lens1_offset_x, self.lens2_offset_x]) + np.random.normal(scale=self.jitter.lens_offset_x, size=2)
         dxps = np.random.normal(scale=self.jitter.lens_angle_x, size=2)
         dys = np.array([self.lens1_offset_y, self.lens2_offset_y]) + np.random.normal(scale=self.jitter.lens_offset_y, size=2)
         dyps = np.random.normal(scale=self.jitter.lens_angle_y, size=2)

--- a/src/abel/classes/runnable.py
+++ b/src/abel/classes/runnable.py
@@ -26,8 +26,9 @@ class Runnable(ABC):
         
         # check if object exists
         if not self.overwrite and os.path.exists(self.object_path(shot)):
-            print('>> SHOT ' + str(shot+1) + ' already exists and will not be overwritten.', flush=True)
-            
+            verbose_exists = self.verbose
+            if verbose_exists:
+                print('>> SHOT ' + str(shot+1) + ' already exists and will not be overwritten.', flush=True)
         else:
 
             # clear the shot folder
@@ -371,28 +372,44 @@ class Runnable(ABC):
         return val_mean, val_std
             
 
-    def extract_function(self, fcn, clean=False):
+    def extract_function(self, fcn, clean=False, parallel=True, max_cores=16):
 
         import inspect
 
         # Prepare the arrays
         val_mean = np.empty(self.num_steps)
         val_std = np.empty(self.num_steps)
-
+        
         # Extract values
         if self.is_scan():
             for step in range(self.num_steps):
                 
                 # Get values for this step
                 val_output = np.empty(self.num_shots_per_step)
-                for shot_in_step in range(self.num_shots_per_step):
-                    
+                
+                def runfcn(shot):
                     input_list = inspect.signature(fcn).parameters
                     if 'clean' in input_list:  # Check if the input list contains clean.
-                        val_output[shot_in_step] = fcn(self[step, shot_in_step], clean=clean)
+                        return fcn(self[step, shot], clean=clean)
                     else:
-                        val_output[shot_in_step] = fcn(self[step, shot_in_step])
+                        return fcn(self[step, shot])
                     
+                if parallel:
+                    
+                    from joblib import Parallel, delayed
+                    
+                    # recalculate number of cores used
+                    num_cores = min(max_cores, self.num_shots_per_step)
+                    
+                    # perform parallel tracking
+                    output_generator = Parallel(n_jobs=num_cores)(delayed(runfcn)(shot_in_step) for shot_in_step in range(self.num_shots_per_step))
+                    val_output = list(output_generator)
+                    
+                else:   
+                    
+                    for shot_in_step in range(self.num_shots_per_step):
+                        val_output[shot_in_step] = runfcn(shot_in_step)
+                        
                 # Get step mean and error
                 val_mean[step] = np.mean(val_output)
                 val_std[step] = np.std(val_output)

--- a/src/abel/utilities/beam_physics.py
+++ b/src/abel/utilities/beam_physics.py
@@ -679,17 +679,17 @@ def evolve_second_order_dispersion(ls, inv_rhos, ks, ms, taus, fast=False, plot=
 
     # dispersion evolution up to fourth order (see https://en.wikipedia.org/wiki/Five-point_stencil)
     # here the dispersion is defined as x(delta) = x_0 + Dx*delta + DDx*delta^2 + DDDx*delta^3 + DDDDx*delta^4 + O(delta^5)
-    # this definition requires multiplying by the factorial of the order
+    # this definition requires dividing by the factorial of the order
     if not fast:
         evolution[0,:] = ss
         evolution[1,:] = (-xs[:,4] + 8*xs[:,3] - 8*xs[:,1] + xs[:,0])/(12*delta)  # First order
-        evolution[2,:] = 2*(-xs[:,4] + 16*xs[:,3] - 30*xs[:,2] + 16*xs[:,1] - xs[:,0])/(12*delta**2)  # Second order
-        evolution[3,:] = 3*2*(xs[:,4] - 2*xs[:,3] + 2*xs[:,1] - xs[:,0])/(2*delta**3)  # Third order
-        evolution[4,:] = 4*3*2*(xs[:,4] - 4*xs[:,3] + 6*xs[:,2] - 4*xs[:,1] + xs[:,0])/delta**4  # Fourth order
+        evolution[2,:] = (-xs[:,4] + 16*xs[:,3] - 30*xs[:,2] + 16*xs[:,1] - xs[:,0])/(12*delta**2) / 2  # Second order
+        evolution[3,:] = (xs[:,4] - 2*xs[:,3] + 2*xs[:,1] - xs[:,0])/(2*delta**3) / (3*2) # Third order
+        evolution[4,:] = (xs[:,4] - 4*xs[:,3] + 6*xs[:,2] - 4*xs[:,1] + xs[:,0])/delta**4 / (4*3*2)  # Fourth order
 
     # return dispersions
-    DDx = 2*(-x[4] + 16*x[3] - 30*x[2] + 16*x[1] - x[0])/(12*delta**2)
-    DDpx = 2*(-xp[4] + 16*xp[3] - 30*xp[2] + 16*xp[1] - xp[0])/(12*delta**2) # Second order
+    DDx = (-x[4] + 16*x[3] - 30*x[2] + 16*x[1] - x[0])/(12*delta**2) / 2
+    DDpx = (-xp[4] + 16*xp[3] - 30*xp[2] + 16*xp[1] - xp[0])/(12*delta**2) / 2 # Second order
     
     if plot:
         from matplotlib import pyplot as plt


### PR DESCRIPTION
This PR is a final "cleanup" for the interstage work. 
- It contains a bug fix in the `beam_physics` utility, now dividing instead of multiplying by the factorial in higher-order dispersion calculations (the second-order dispersion is used a lot and was off by a factor 4).
- Visual improvements to the interstage optics and layout plots, including adding drivers.
- Some additional control parameters of density plots in Beam.
- Added parallel loading of data in Runnable (used in interstage paper figures).
- Renamed the `isr_on_ref_part` parameter in the ImpactX interstage (to be more self-consistent).
- Removed the ISR kick mitigation offsets (not handled by adding ISR directly to the reference particle).
- Fixed bug in the ImpactX interstage where the second lens was overwritten by the first.