### PR TITLE
Small HiPACE++ fixes

### DIFF
--- a/src/abel/classes/stage/impl/stage_hipace.py
+++ b/src/abel/classes/stage/impl/stage_hipace.py
@@ -348,7 +348,7 @@ class StageHipace(Stage):
             output_period = None
         
         # input file
-        filename_input = 'input_file'
+        filename_input = 'input_file_stage' + str(self.stage_number)
         path_input = tmpfolder + filename_input
         hipace_write_inputs(path_input, filename_beam, filename_driver, self.plasma_density, self.num_steps, time_step, box_range_z, box_size_xy, ion_motion=self.ion_motion, ion_species=self.ion_species, beam_ionization=self.beam_ionization, radiation_reaction=self.radiation_reaction, output_period=output_period, num_cell_xy=self.num_cell_xy, num_cell_z=num_cell_z, driver_only=self.driver_only, density_table_file=density_table_file, no_plasma=self.no_plasma, external_focusing_gradient=self._external_focusing_gradient, mesh_refinement=self.mesh_refinement, do_spin_tracking=self.do_spin_tracking)
         
@@ -398,10 +398,6 @@ class StageHipace(Stage):
         # extract insitu diagnostics and wakefield data
         self.__extract_evolution(tmpfolder, beam0, runnable)
         self.__extract_initial_and_final_step(tmpfolder, beam0, runnable)
-
-        # move the HiPACE++ input file to be stored
-        if self.run_path is not None:
-            shutil.move(path_input, self.run_path)
         
         # delete temp folder
         shutil.rmtree(tmpfolder)

--- a/src/abel/wrappers/hipace/read_insitu_diagnostics.py
+++ b/src/abel/wrappers/hipace/read_insitu_diagnostics.py
@@ -10,14 +10,15 @@ from numpy.lib import recfunctions as rfn
 import glob
 import json
 from scipy import constants
+from concurrent.futures import ThreadPoolExecutor
 
-def get_buffer(file):
+def get_buffer(file, decoder):
     with open(file, "rb") as f:
         bytes = f.read()
-        datatype_obj = json.JSONDecoder().raw_decode(bytes.decode(errors="replace"))
+        datatype_obj = decoder.raw_decode(bytes.decode(errors="replace"))
     return {"buffer" : bytes, "dtype" : np.dtype(datatype_obj[0]), "offset" : datatype_obj[1]}
 
-def read_file(filenames):
+def read_file(filenames, max_workers=16):
     """
     Extract insitu diagnostics into a NumPy structured array
 
@@ -36,9 +37,23 @@ def read_file(filenames):
     For these weighted averages and totals over slices are also available.
     Use .dtype or .dtype.names to get a list of available components
     """
-    return np.sort(rfn.stack_arrays([
-        np.frombuffer(**get_buffer(file)) for file in glob.iglob(filenames)
-    ], usemask=False, asrecarray=False, autoconvert=True), order="time")
+    
+    decoder = json.JSONDecoder()
+    files = list(glob.iglob(filenames))
+    
+    def read_one(file):
+        return np.frombuffer(**get_buffer(file, decoder))
+    
+    with ThreadPoolExecutor(max_workers=max_workers) as ex:
+        arrays = list(ex.map(read_one, files))
+    
+    arr = np.concatenate(arrays, axis=0)
+    arr.sort(order="time")
+    return arr
+    
+    #return np.sort(rfn.stack_arrays([
+    #    np.frombuffer(**get_buffer(file)) for file in glob.iglob(filenames)
+    #], usemask=False, asrecarray=False, autoconvert=True), order="time")
 
 def emittance_x(all_data):
     """


### PR DESCRIPTION
Mainly to run more smoothly (less crashes and more quickly).
- Removes the moving of the input file to the run folder (as this can often collide with other files).
- Renames the input file to be unique per stage (less collisions).
- Faster reading of insitu files by being parallelized. This part was very slow before (when using many GPUs).